### PR TITLE
Fix off-by-one error. 0x800 interpreted as signed two's-complement is…

### DIFF
--- a/posts/riscv-arithmetic/index.html
+++ b/posts/riscv-arithmetic/index.html
@@ -355,7 +355,7 @@
 </span></span></span></code></pre></div><p>The <strong>nop</strong> instruction advances the program counter but makes no other changes. A standard <strong>nop</strong> encoding clarifies the programmer&rsquo;s intent and prevents the instruction from being optimised away.</p>
 <h3 id="sign-extension">Sign Extension</h3>
 <p>RISC-V immediates are sign extended. The most significant bit (MSB) fills the remaining bits to create a 32-bit value. A 12-bit RISC-V immediate can represent -2048 to 2047 inclusive.</p>
-<p>Sign extension of -2047 decimal (MSB=1):</p>
+<p>Sign extension of -2048 decimal (MSB=1):</p>
 <p><code>1000 0000 0000 -&gt; 1111 1111 1111 1111 1111 1000 0000 0000</code></p>
 <p>Sign extension of 1033 decimal (MSB=0):</p>
 <p><code>0100 0000 1001 -&gt; 0000 0000 0000 0000 0000 0100 0000 1001</code></p>


### PR DESCRIPTION
… -2048.

This had me scratching my head for a while wondering where my calculation was off.